### PR TITLE
Check for http request returning error type

### DIFF
--- a/includes/class-wc-siftscience-stats.php
+++ b/includes/class-wc-siftscience-stats.php
@@ -132,6 +132,7 @@ if ( ! class_exists( "WC_SiftScience_Stats" ) ) :
 			$result = wp_remote_request( $url, $request );
 
 			$is_success = isset( $result )
+			              && ! is_wp_error( $result )
 			              && isset( $result[ 'response' ] )
 			              && isset( $result[ 'response' ][ 'code' ] )
 			              && 200 === $result[ 'response' ][ 'code' ];


### PR DESCRIPTION
I found the bug in the code. When you make a remote request, you should check if the return value is not a WP_Error type.

Closes #103 