### PR TITLE
Make nonce action names unique and auto-generated

### DIFF
--- a/includes/class-wc-siftscience-admin.php
+++ b/includes/class-wc-siftscience-admin.php
@@ -22,12 +22,12 @@ if ( ! class_exists( 'WC_SiftScience_Admin' ) ) :
 	class WC_SiftScience_Admin {
 		private const ADMIN_ID            = 'siftsci';
 		private const ADMIN_LABEL         = 'Sift';
-		private const GET_VAR_CLEAR_STATS = 'clear_stats';
-		private const GET_VAR_SET_STATS   = 'set_siftsci_stats';
-		private const GET_VAR_RESET_GUID  = 'reset_guid';
-		private const GET_VAR_TEST_SSL    = 'test_ssl';
-		private const GET_VAR_CLEAR_LOGS  = 'clear_logs';
-		private const NONCE_ACTION_PREFIX = 'woocommerce_settings_nonce_';
+		private const GET_VAR_SET_STATS   = 'wc_sift_send_stats';
+		private const GET_VAR_CLEAR_STATS = 'wc_sift_clear_stats';
+		private const GET_VAR_RESET_GUID  = 'wc_sift_reset_guid';
+		private const GET_VAR_TEST_SSL    = 'wc_sift_test_ssl';
+		private const GET_VAR_CLEAR_LOGS  = 'wc_sift_clear_logs';
+		private const NONCE_ACTION_PREFIX = 'wc_sift_nonce_';
 
 		private const ALLOWED_HTML = array(
 			'li'    => array(),

--- a/includes/class-wc-siftscience-admin.php
+++ b/includes/class-wc-siftscience-admin.php
@@ -607,12 +607,11 @@ IMPROVE;
 		 * @return String|False $result if the get var and it's nonce are valid return it's value else return false.
 		 */
 		private function get_value( $var_name ) {
-			$action = self::NONCE_ACTION_PREFIX . $var_name;
 			$nonce_name = $this->get_nonce_name( $var_name );
 
 			// Check that nonce is valid and input value exists.
 			$is_valid_input = isset( $_GET[ $var_name ], $_GET[ $nonce_name ] )
-				&& wp_verify_nonce( sanitize_key( $_GET[ $nonce_name ] ), $action );
+				&& wp_verify_nonce( sanitize_key( $_GET[ $nonce_name ] ), $this->get_action_name( $var_name ) );
 
 			if ( false === $is_valid_input ) {
 				return false;
@@ -631,6 +630,18 @@ IMPROVE;
 		private function get_nonce_name( $get_var ) {
 			return $get_var . '_nonce';
 		}
+
+		/**
+		 * This function auto-generates the nonce action name based on the get variable name
+		 *
+		 * @param String $get_var the GET array variable.
+		 *
+		 * @return String concatenated nonce name.
+		 */
+		private function get_action_name( $get_var ) {
+			return self::NONCE_ACTION_PREFIX . $get_var;
+		}
+
 		/**
 		 * Creates a variable URL with it's nonce respectivly
 		 *
@@ -640,9 +651,8 @@ IMPROVE;
 		 * @return String bounded link with a get var and it's nonce.
 		 */
 		private function bound_nonce_url( $get_var_name, $get_var_value ) {
-			$action = self::NONCE_ACTION_PREFIX . $get_var_name;
 			$url = add_query_arg( array( $get_var_name => $get_var_value ) );
-			$url = wp_nonce_url( $url, $action, $this->get_nonce_name( $get_var_name ) );
+			$url = wp_nonce_url( $url, $this->get_action_name( $get_var_name ), $this->get_nonce_name( $get_var_name ) );
 			return $url;
 		}
 		/**

--- a/includes/class-wc-siftscience-admin.php
+++ b/includes/class-wc-siftscience-admin.php
@@ -22,7 +22,11 @@ if ( ! class_exists( 'WC_SiftScience_Admin' ) ) :
 	class WC_SiftScience_Admin {
 		private const ADMIN_ID    = 'siftsci';
 		private const ADMIN_LABEL = 'Sift';
-		private const VAR_KEY_STATS = 'set_siftsci_stats';
+		private const GET_VAR_CLEAR_STATS = 'clear_stats';
+		private const GET_VAR_SET_STATS = 'set_siftsci_stats';
+		private const GET_VAR_RESET_GUID = 'reset_guid';
+		private const GET_VAR_TEST_SSL = 'test_ssl';
+		private const GET_VAR_CLEAR_LOGS = 'clear_logs';
 		private const NONCE_ACTION_PREFIX  = 'woocommerce_settings_nonce_';
 
 		private const ALLOWED_HTML = array(
@@ -219,11 +223,11 @@ table;
 		private function output_settings_debug() {
 			$log_file = dirname( __DIR__ ) . '/debug.log';
 
-			if ( '1' === $this->get_value( 'clear_logs' ) ) {
+			if ( '1' === $this->get_value( self::GET_VAR_CLEAR_LOGS ) ) {
 				// @codingStandardsIgnoreStart
 				$fh = fopen( $log_file, 'w' );
 				fclose( $fh );
-				wp_safe_redirect( $this->unbound_nonce_url( 'clear_logs' ) );
+				wp_safe_redirect( $this->unbound_nonce_url( self::GET_VAR_CLEAR_LOGS ) );
 				// @codingStandardsIgnoreEnd
 				exit;
 			}
@@ -238,7 +242,7 @@ table;
 				// @codingStandardsIgnoreEnd
 			}
 
-			if ( '1' === $this->get_value( 'test_ssl' ) ) {
+			if ( '1' === $this->get_value( self::GET_VAR_TEST_SSL ) ) {
 				// SSL check logic.
 				// Note: I found how to do this here: https://tecadmin.net/test-tls-version-php/.
 				// @codingStandardsIgnoreStart
@@ -253,7 +257,7 @@ table;
 				$data = "<p>TLS Version: $tls_version</p>\n<p>Full Data: $data</p>\n";
 
 				set_transient( 'wc-siftsci-ssl-log', $data );
-				wp_safe_redirect( $this->unbound_nonce_url( 'test_ssl' ) );
+				wp_safe_redirect( $this->unbound_nonce_url( self::GET_VAR_TEST_SSL ) );
 				exit;
 			}
 
@@ -265,14 +269,14 @@ table;
 				echo wp_kses( $ssl_data, self::ALLOWED_HTML );
 			}
 
-			$ssl_url = $this->bound_nonce_url( 'test_ssl', '1' );
+			$ssl_url = $this->bound_nonce_url( self::GET_VAR_TEST_SSL, '1' );
 			echo wp_kses( '<a href="' . $ssl_url . '" class="button-primary woocommerce-save-button">Test SSL</a>', self::ALLOWED_HTML );
 
 			// Display logs.
 			echo '<h2>Logs</h2>';
 			echo wp_kses( '<p>' . nl2br( esc_html( $logs ) ) . '</p>', self::ALLOWED_HTML );
 
-			$log_url = $this->bound_nonce_url( 'clear_logs', '1' );
+			$log_url = $this->bound_nonce_url( self::GET_VAR_CLEAR_LOGS, '1' );
 			echo wp_kses( '<a href="' . $log_url . '" class="button-primary woocommerce-save-button">Clear Logs</a>', self::ALLOWED_HTML );
 		}
 
@@ -280,9 +284,9 @@ table;
 		 * Outputs the reporting tab in settings
 		 */
 		private function output_settings_reporting() {
-			if ( '1' === $this->get_value( 'reset_guid' ) ) {
+			if ( '1' === $this->get_value( self::GET_VAR_RESET_GUID ) ) {
 				delete_option( WC_SiftScience_Options::GUID );
-				wp_safe_redirect( $this->unbound_nonce_url( 'reset_guid' ) );
+				wp_safe_redirect( $this->unbound_nonce_url( self::GET_VAR_RESET_GUID ) );
 				exit();
 			}
 			WC_Admin_Settings::output_fields( $this->get_settings_stats() );
@@ -294,9 +298,9 @@ table;
 		 */
 		private function output_settings_stats() {
 			$GLOBALS['hide_save_button'] = true;
-			if ( '1' === $this->get_value( 'clear_stats' ) ) {
+			if ( '1' === $this->get_value( self::GET_VAR_CLEAR_STATS ) ) {
 				$this->stats->clear_stats();
-				wp_safe_redirect( $this->unbound_nonce_url( 'clear_stats' ) );
+				wp_safe_redirect( $this->unbound_nonce_url( self::GET_VAR_CLEAR_STATS ) );
 				exit;
 			}
 
@@ -335,7 +339,7 @@ STATS_TABLE;
 
 			echo wp_kses( $stats_tables, self::ALLOWED_HTML );
 
-			$url = $this->bound_nonce_url( 'clear_stats', '1' );
+			$url = $this->bound_nonce_url( self::GET_VAR_CLEAR_STATS, '1' );
 			echo wp_kses( '<a href="' . $url . '" class="button-primary woocommerce-save-button">Clear Stats</a>', self::ALLOWED_HTML );
 		}
 
@@ -345,7 +349,7 @@ STATS_TABLE;
 		 * @return Array []
 		 */
 		private function get_settings_stats() {
-			$reset_url = $this->bound_nonce_url( 'reset_guid', '1' );
+			$reset_url = $this->bound_nonce_url( self::GET_VAR_RESET_GUID, '1' );
 			$reset_anchor = ' <a href="' . $reset_url . '">Reset</a>';
 
 			return array(
@@ -570,15 +574,15 @@ NOTICE;
 				return;
 			}
 
-			$value = $this->get_value( self::VAR_KEY_STATS, self::NONCE_ACTION_STATS );
+			$value = $this->get_value( self::GET_VAR_SET_STATS, self::NONCE_ACTION_STATS );
 			if ( false !== $value ) {
 				update_option( WC_SiftScience_Options::SEND_STATS, $value );
-				wp_safe_redirect( $this->unbound_nonce_url( self::VAR_KEY_STATS ) );
+				wp_safe_redirect( $this->unbound_nonce_url( self::GET_VAR_SET_STATS ) );
 				exit;
 			}
 
-			$no_url = $this->bound_nonce_url( self::VAR_KEY_STATS, 'no' );
-			$yes_url = $this->bound_nonce_url( self::VAR_KEY_STATS, 'yes' );
+			$no_url = $this->bound_nonce_url( self::GET_VAR_SET_STATS, 'no' );
+			$yes_url = $this->bound_nonce_url( self::GET_VAR_SET_STATS, 'yes' );
 
 			$no_anchor  = '<a href="' . $no_url . '">Disable</a>';
 			$yes_anchor = '<a href="' . $yes_url . '">Enable</a>';

--- a/includes/class-wc-siftscience-admin.php
+++ b/includes/class-wc-siftscience-admin.php
@@ -27,7 +27,7 @@ if ( ! class_exists( 'WC_SiftScience_Admin' ) ) :
 		private const GET_VAR_RESET_GUID  = 'wc_sift_reset_guid';
 		private const GET_VAR_TEST_SSL    = 'wc_sift_test_ssl';
 		private const GET_VAR_CLEAR_LOGS  = 'wc_sift_clear_logs';
-		private const NONCE_ACTION_PREFIX = 'wc_sift_nonce_';
+		private const NONCE_ACTION_PREFIX = 'nonce_action_';
 
 		private const ALLOWED_HTML = array(
 			'li'    => array(),

--- a/includes/class-wc-siftscience-admin.php
+++ b/includes/class-wc-siftscience-admin.php
@@ -574,18 +574,15 @@ NOTICE;
 				return;
 			}
 
-			$value = $this->get_value( self::GET_VAR_SET_STATS, self::NONCE_ACTION_STATS );
+			$value = $this->get_value( self::GET_VAR_SET_STATS );
 			if ( false !== $value ) {
 				update_option( WC_SiftScience_Options::SEND_STATS, $value );
 				wp_safe_redirect( $this->unbound_nonce_url( self::GET_VAR_SET_STATS ) );
 				exit;
 			}
 
-			$no_url  = $this->bound_nonce_url( self::GET_VAR_SET_STATS, 'no' );
-			$yes_url = $this->bound_nonce_url( self::GET_VAR_SET_STATS, 'yes' );
-
-			$no_anchor  = '<a href="' . $no_url . '">Disable</a>';
-			$yes_anchor = '<a href="' . $yes_url . '">Enable</a>';
+			$no_anchor  = $this->get_stats_anchor( 'Disable', 'no' );
+			$yes_anchor = $this->get_stats_anchor( 'Enable', 'yes' );
 
 			$link_info      = 'https://github.com/Fermiac/woocommerce-siftscience/wiki/Statistics-Collection';
 			$details_anchor = '<a target="_blank" href="' . $link_info . '">more info</a>';
@@ -599,6 +596,20 @@ NOTICE;
 IMPROVE;
 			echo wp_kses( $improve, self::ALLOWED_HTML );
 		}
+
+		/**
+		 * Gets the anchor HTML for the enable/disable links for stats
+		 *
+		 * @param string $text The text to display in the anchor.
+		 * @param string $value The get param value to put in the URL.
+		 *
+		 * @return string
+		 */
+		private function get_stats_anchor( $text, $value ) {
+			$url = $this->bound_nonce_url( self::GET_VAR_SET_STATS, $value );
+			return "<a href='{$url}'>{$text}</a>";
+		}
+
 		/**
 		 * This function will validate GET var with its nonce
 		 *
@@ -655,6 +666,7 @@ IMPROVE;
 			$url = wp_nonce_url( $url, $this->get_action_name( $get_var_name ), $this->get_nonce_name( $get_var_name ) );
 			return $url;
 		}
+
 		/**
 		 * Retunning a URL dispatching the required GET var and the nonce related
 		 *

--- a/includes/class-wc-siftscience-admin.php
+++ b/includes/class-wc-siftscience-admin.php
@@ -20,14 +20,14 @@ if ( ! class_exists( 'WC_SiftScience_Admin' ) ) :
 	 * Class WC_SiftScience_Admin
 	 */
 	class WC_SiftScience_Admin {
-		private const ADMIN_ID    = 'siftsci';
-		private const ADMIN_LABEL = 'Sift';
+		private const ADMIN_ID            = 'siftsci';
+		private const ADMIN_LABEL         = 'Sift';
 		private const GET_VAR_CLEAR_STATS = 'clear_stats';
-		private const GET_VAR_SET_STATS = 'set_siftsci_stats';
-		private const GET_VAR_RESET_GUID = 'reset_guid';
-		private const GET_VAR_TEST_SSL = 'test_ssl';
-		private const GET_VAR_CLEAR_LOGS = 'clear_logs';
-		private const NONCE_ACTION_PREFIX  = 'woocommerce_settings_nonce_';
+		private const GET_VAR_SET_STATS   = 'set_siftsci_stats';
+		private const GET_VAR_RESET_GUID  = 'reset_guid';
+		private const GET_VAR_TEST_SSL    = 'test_ssl';
+		private const GET_VAR_CLEAR_LOGS  = 'clear_logs';
+		private const NONCE_ACTION_PREFIX = 'woocommerce_settings_nonce_';
 
 		private const ALLOWED_HTML = array(
 			'li'    => array(),
@@ -349,7 +349,7 @@ STATS_TABLE;
 		 * @return Array []
 		 */
 		private function get_settings_stats() {
-			$reset_url = $this->bound_nonce_url( self::GET_VAR_RESET_GUID, '1' );
+			$reset_url    = $this->bound_nonce_url( self::GET_VAR_RESET_GUID, '1' );
 			$reset_anchor = ' <a href="' . $reset_url . '">Reset</a>';
 
 			return array(
@@ -581,7 +581,7 @@ NOTICE;
 				exit;
 			}
 
-			$no_url = $this->bound_nonce_url( self::GET_VAR_SET_STATS, 'no' );
+			$no_url  = $this->bound_nonce_url( self::GET_VAR_SET_STATS, 'no' );
 			$yes_url = $this->bound_nonce_url( self::GET_VAR_SET_STATS, 'yes' );
 
 			$no_anchor  = '<a href="' . $no_url . '">Disable</a>';


### PR DESCRIPTION
- The $action param is not the name of the hook, it should be as unique as possible to the request.
- We can make the action name unique based on a the name of the GET_VAR that it's protecting.
- This way, we don't need a different constant for each usage, we can generate an action name based on the GET_VAR.

Bonus change:
- Took all the constant strings out of functions and into const at the top of the class.