### PR TITLE
Simplify the reporting settings page

### DIFF
--- a/includes/class-wc-siftscience-admin.php
+++ b/includes/class-wc-siftscience-admin.php
@@ -306,9 +306,11 @@ STATS_TABLE;
 		 * @return Array []
 		 */
 		private function get_settings_reporting() {
-			$anon_id   = $this->options->get_guid();
-			$rest_url  = $this->bound_nonce_url( self::GET_VAR_RESET_GUID, '1' );
-			$anon_text = "$anon_id <a href='$rest_url'>Reset</a>";
+			$anon_id              = $this->options->get_guid();
+			$rest_url             = $this->bound_nonce_url( self::GET_VAR_RESET_GUID, '1' );
+			$anon_text            = "$anon_id <a href='$rest_url'>Reset</a>";
+			$checkbox_description = 'Help us improve this plugin by automatically reporting errors and statistics. ' .
+				'More info <a target="_blank" href="https://github.com/Fermiac/woocommerce-siftscience/wiki/Statistics-Collection">here</a>.';
 
 			return array(
 				$this->create_element(
@@ -330,9 +332,7 @@ STATS_TABLE;
 					'Enable Reporting',
 					'Send anonymous statistics and error details.',
 					array(
-						'desc_tip' =>
-							'Help us improve this plugin by automatically reporting errors and statistics. ' .
-							'More info <a target="_blank" href="https://github.com/Fermiac/woocommerce-siftscience/wiki/Statistics-Collection">here</a>.',
+						'desc_tip' => $checkbox_description,
 					)
 				),
 

--- a/includes/class-wc-siftscience-admin.php
+++ b/includes/class-wc-siftscience-admin.php
@@ -660,7 +660,7 @@ STATS_TABLE;
 		private function get_anon_id_content() {
 			$anon_id  = $this->options->get_guid();
 			$rest_url = $this->bound_nonce_url( self::GET_VAR_RESET_GUID, '1' );
-			return "$anon_id <a href='$rest_url'>Reset</a>";
+			return "$anon_id (<a href='$rest_url'>Reset</a>)";
 		}
 
 		/**
@@ -671,7 +671,7 @@ STATS_TABLE;
 		private function get_reporting_checkbox_description() {
 			$url     = 'https://github.com/Fermiac/woocommerce-siftscience/wiki/Statistics-Collection';
 			$message = 'Help us improve this plugin by automatically reporting errors and statistics. ';
-			return "$message More info <a target='_blank' href='$url'>here</a>";
+			return "$message More info <a target='_blank' href='$url'>here</a>.";
 		}
 	}
 endif;

--- a/includes/class-wc-siftscience-admin.php
+++ b/includes/class-wc-siftscience-admin.php
@@ -530,6 +530,11 @@ STATS_TABLE;
 			}
 
 			switch ( $type ) {
+				case WC_SiftScience_Html::WC_CUSTOM_ELEMENT:
+					$type     = 'wc_sift_' . $id; // this is the custom type name needed by WooCommerce.
+					$callback = array( $this->html, 'display_custom_settings_row' );
+					add_action( 'woocommerce_admin_field_' . $type, $callback ); // This intentionally falls through to the next section.
+
 				case WC_SiftScience_Html::WC_NUMBER_ELEMENT:
 				case WC_SiftScience_Html::WC_TEXT_ELEMENT:
 				case WC_SiftScience_Html::WC_CHECKBOX_ELEMENT:
@@ -551,16 +556,6 @@ STATS_TABLE;
 				case WC_SiftScience_Html::WC_SECTIONEND_ELEMENT:
 					$element['id']   = $id;
 					$element['type'] = $type;
-					break;
-
-				case WC_SiftScience_Html::WC_CUSTOM_ELEMENT:
-					$action_name = 'woocommerce_admin_field_wc_sift_' . $id;
-					$callback    = array( $this->html, 'display_custom_settings_row' );
-					add_action( $action_name, $callback );
-
-					$element['type']  = 'wc_sift_' . $id;
-					$element['title'] = $label;
-					$element['desc']  = $desc;
 					break;
 
 				default:

--- a/includes/class-wc-siftscience-admin.php
+++ b/includes/class-wc-siftscience-admin.php
@@ -306,10 +306,6 @@ STATS_TABLE;
 		 * @return Array []
 		 */
 		private function get_settings_reporting() {
-			$reset_url    = esc_url( $this->bound_nonce_url( self::GET_VAR_RESET_GUID, '1' ) );
-			$anonymous_id = $this->options->get_guid();
-			$anon_id_text = "$anonymous_id <a href='$reset_url'>reset</a>";
-
 			return array(
 				$this->create_element(
 					WC_SiftScience_Html::WC_TITLE_ELEMENT,
@@ -321,7 +317,10 @@ STATS_TABLE;
 					WC_SiftScience_Html::WC_CUSTOM_ELEMENT,
 					'anon_id',
 					'Anonymous ID',
-					$anon_id_text
+					$this->html->get_anon_id_text(
+						$this->options->get_guid(),
+						$this->bound_nonce_url( self::GET_VAR_RESET_GUID, '1' )
+					)
 				),
 
 				$this->create_element(
@@ -554,13 +553,14 @@ STATS_TABLE;
 					break;
 
 				case WC_SiftScience_Html::WC_CUSTOM_ELEMENT:
-					add_action(
-						'woocommerce_admin_field_wc_sift_' . $id,
-						function () use ( $label, $desc ) {
-							$this->html->display_settings_row( $label, $desc );
-						}
-					);
-					return array( 'type' => 'wc_sift_' . $id );
+					$action_name = 'woocommerce_admin_field_wc_sift_' . $id;
+					$callback    = array( $this->html, 'display_custom_settings_row' );
+					add_action( $action_name, $callback );
+
+					$element['type']  = 'wc_sift_' . $id;
+					$element['title'] = $label;
+					$element['desc']  = $desc;
+					break;
 
 				default:
 					$this->logger->log_error( $type . ' is not a valid type!' );

--- a/includes/class-wc-siftscience-admin.php
+++ b/includes/class-wc-siftscience-admin.php
@@ -306,12 +306,6 @@ STATS_TABLE;
 		 * @return Array []
 		 */
 		private function get_settings_reporting() {
-			$anon_id              = $this->options->get_guid();
-			$rest_url             = $this->bound_nonce_url( self::GET_VAR_RESET_GUID, '1' );
-			$anon_text            = "$anon_id <a href='$rest_url'>Reset</a>";
-			$checkbox_description = 'Help us improve this plugin by automatically reporting errors and statistics. ' .
-				'More info <a target="_blank" href="https://github.com/Fermiac/woocommerce-siftscience/wiki/Statistics-Collection">here</a>.';
-
 			return array(
 				$this->create_element(
 					WC_SiftScience_Html::WC_TITLE_ELEMENT,
@@ -323,7 +317,7 @@ STATS_TABLE;
 					WC_SiftScience_Html::WC_CUSTOM_ELEMENT,
 					'anon_id',
 					'Anonymous ID',
-					$anon_text
+					$this->get_anon_id_content()
 				),
 
 				$this->create_element(
@@ -331,9 +325,7 @@ STATS_TABLE;
 					WC_SiftScience_Options::SEND_STATS,
 					'Enable Reporting',
 					'Send anonymous statistics and error details.',
-					array(
-						'desc_tip' => $checkbox_description,
-					)
+					array( 'desc_tip' => $this->get_reporting_checkbox_description() )
 				),
 
 				$this->create_element(
@@ -658,6 +650,28 @@ STATS_TABLE;
 		 */
 		private function unbound_nonce_url( $get_var_name ) {
 			return remove_query_arg( array( $get_var_name, $this->get_nonce_name( $get_var_name ) ) );
+		}
+
+		/**
+		 * Gets the content that goes in the Anonymous ID row in reporting
+		 *
+		 * @return string
+		 */
+		private function get_anon_id_content() {
+			$anon_id  = $this->options->get_guid();
+			$rest_url = $this->bound_nonce_url( self::GET_VAR_RESET_GUID, '1' );
+			return "$anon_id <a href='$rest_url'>Reset</a>";
+		}
+
+		/**
+		 * Gets the content that goes in the description under the reporting
+		 *
+		 * @return string
+		 */
+		private function get_reporting_checkbox_description() {
+			$url     = 'https://github.com/Fermiac/woocommerce-siftscience/wiki/Statistics-Collection';
+			$message = 'Help us improve this plugin by automatically reporting errors and statistics. ';
+			return "$message More info <a target='_blank' href='$url'>here</a>";
 		}
 	}
 endif;

--- a/includes/class-wc-siftscience-admin.php
+++ b/includes/class-wc-siftscience-admin.php
@@ -306,6 +306,10 @@ STATS_TABLE;
 		 * @return Array []
 		 */
 		private function get_settings_reporting() {
+			$anon_id   = $this->options->get_guid();
+			$rest_url  = $this->bound_nonce_url( self::GET_VAR_RESET_GUID, '1' );
+			$anon_text = "$anon_id <a href='$rest_url'>Reset</a>";
+
 			return array(
 				$this->create_element(
 					WC_SiftScience_Html::WC_TITLE_ELEMENT,
@@ -317,10 +321,7 @@ STATS_TABLE;
 					WC_SiftScience_Html::WC_CUSTOM_ELEMENT,
 					'anon_id',
 					'Anonymous ID',
-					$this->html->get_anon_id_text(
-						$this->options->get_guid(),
-						$this->bound_nonce_url( self::GET_VAR_RESET_GUID, '1' )
-					)
+					$anon_text
 				),
 
 				$this->create_element(

--- a/includes/class-wc-siftscience-html.php
+++ b/includes/class-wc-siftscience-html.php
@@ -137,20 +137,33 @@ if ( ! class_exists( 'WC_SiftScience_Html' ) ) :
 		/**
 		 * This function displays a custom row in the admin settings page
 		 *
-		 * @param String $label   The label to display on the left side of the table.
-		 * @param String $content The content to display on the right side.
+		 * @param Array $data The data array of this setting line.
 		 */
-		public function display_settings_row( $label, $content ) {
+		public function display_custom_settings_row( $data ) {
+			$title   = $data['title'];
+			$content = $data['desc'];
 			?>
 			<tr valign="top">
 				<th scope="row" class="titledesc">
-					<label><?php echo wp_kses( $label, $this->allowed_tags ); ?></label>
+					<?php echo wp_kses( $title, $this->allowed_tags ); ?>
 				</th>
 				<td class="forminp">
 					<?php echo wp_kses( $content, $this->allowed_tags ); ?>
 				</td>
 			</tr>
 			<?php
+		}
+
+		/**
+		 * Creates the text for anonymous ID setting row
+		 *
+		 * @param String $id   The current anon id.
+		 * @param String $link The link to reset the anon id.
+		 *
+		 * @return string
+		 */
+		public function get_anon_id_text( $id, $link ) {
+			return "$id <a href='$link'>Reset</a>";
 		}
 	}
 endif;

--- a/includes/class-wc-siftscience-html.php
+++ b/includes/class-wc-siftscience-html.php
@@ -153,17 +153,5 @@ if ( ! class_exists( 'WC_SiftScience_Html' ) ) :
 			</tr>
 			<?php
 		}
-
-		/**
-		 * Creates the text for anonymous ID setting row
-		 *
-		 * @param String $id   The current anon id.
-		 * @param String $link The link to reset the anon id.
-		 *
-		 * @return string
-		 */
-		public function get_anon_id_text( $id, $link ) {
-			return "$id <a href='$link'>Reset</a>";
-		}
 	}
 endif;

--- a/includes/class-wc-siftscience-html.php
+++ b/includes/class-wc-siftscience-html.php
@@ -33,6 +33,7 @@ if ( ! class_exists( 'WC_SiftScience_Html' ) ) :
 		public const WC_SELECT_ELEMENT     = 'select';
 		public const WC_CHECKBOX_ELEMENT   = 'checkbox';
 		public const WC_SECTIONEND_ELEMENT = 'sectionend';
+		public const WC_CUSTOM_ELEMENT     = 'custom';
 
 		/**
 		 * A setter for allowed_html field
@@ -132,26 +133,24 @@ if ( ! class_exists( 'WC_SiftScience_Html' ) ) :
 			</table>
 			<?php
 		}
+
 		/**
-		 * This function displayes Reporting header receiving the anonymous id from the admin class
+		 * This function displays a custom row in the admin settings page
 		 *
-		 * @param String $anonymous_id The id sent from admin genarated by options.
-		 * @param String $reset_url    A url to reset the anonymous id.
+		 * @param String $label   The label to display on the left side of the table.
+		 * @param String $content The content to display on the right side.
 		 */
-		public function display_reporting_text( $anonymous_id, $reset_url ) {
+		public function display_settings_row( $label, $content ) {
 			?>
-
-			<h2>Notice</h2>
-			<p> 
-				Help us improve this plugin by automatically reporting errors and statistics.<br /> 
-				All information is anonymous and cannot be traced back to your site.<br />
-				For details, <a target="_blank" href="https://github.com/Fermiac/woocommerce-siftscience/wiki/Statistics-Collection">click here</a>.
-			</p>
-			<p> Your <em>anonymous id</em> is: <?php echo esc_html( $anonymous_id ); ?> <a href="<?php echo esc_url( $reset_url ); ?>"></a></p>
-
+			<tr valign="top">
+				<th scope="row" class="titledesc">
+					<label><?php echo wp_kses( $label, $this->allowed_tags ); ?></label>
+				</th>
+				<td class="forminp">
+					<?php echo wp_kses( $content, $this->allowed_tags ); ?>
+				</td>
+			</tr>
 			<?php
 		}
-
 	}
-
 endif;


### PR DESCRIPTION
This gets rid of the big paragraph of text at the start of the reporting page.

- Anonymous ID view/reset is added to the form
- Shortened the explanation text and added it under the checkbox

![image](https://user-images.githubusercontent.com/11143071/92345193-52dcc600-f07d-11ea-94c6-17ca5d60cefb.png)
