### PR TITLE
create element new stuff 

### DIFF
--- a/includes/class-wc-siftscience-admin.php
+++ b/includes/class-wc-siftscience-admin.php
@@ -343,7 +343,7 @@ if ( ! class_exists( 'WC_SiftScience_Admin' ) ) :
 			return array(
 				$this->create_element(
 					WC_SiftScience_Html::WC_TITLE_ELEMENT,
-					'siftsci_title',
+					'siftsci_title_id',
 					'Sift Settings'
 				),
 
@@ -426,6 +426,26 @@ if ( ! class_exists( 'WC_SiftScience_Admin' ) ) :
 			);
 		}
 
+		public function __call( $name, $args ) {
+			if ( 'WC_SiftScience_Admin::create_element' === $name ) {
+
+				echo 'ra ra ra';
+				switch ( count( $args ) ) {
+					case 2:
+						return $this->create_element( $args[0], $args[1], '', '', array() );
+					case 3:
+						return $this->create_element( $args[0], $args[1], $args[2], '', array() );
+					case 4:
+						return $this->create_element( $args[0], $args[1], $args[2], $args[3], array() );
+					case 5:
+						return $this->create_element( $args[0], $args[1], $args[2], $args[3], $args[4] );
+					default:
+						$this->logger->log_error( 'there is no delaretion method for create_element with ' . count( $args ) . ' arguemnts' );
+						break;
+				}
+			}
+		}
+
 		/**
 		 * This function sets HTML element attributes according to woocommearce provided library.
 		 * desc_tip Mixed [bool:false] (default)
@@ -448,7 +468,7 @@ if ( ! class_exists( 'WC_SiftScience_Admin' ) ) :
 		 * @return array $element         An array of attributes.
 		 * @since 1.1.0
 		 */
-		private function create_element( $type, $id, $label = '', $desc = '', $element_options = array() ) {
+		private function create_element( $type, $id, $labe, $desc, $element_options ) {
 
 			if ( WC_SiftScience_Html::WC_SELECT_ELEMENT === $type ) {
 				if ( ! isset( $element_options['options'] ) || empty( $element_options['options'] ) ) {

--- a/includes/class-wc-siftscience-admin.php
+++ b/includes/class-wc-siftscience-admin.php
@@ -255,20 +255,20 @@ if ( ! class_exists( 'WC_SiftScience_Admin' ) ) :
 		 */
 		private function get_settings_reporting() {
 			return array(
-				$this->create_element(
+				$this->html->create_element(
 					WC_SiftScience_Html::WC_TITLE_ELEMENT,
 					'siftsci_title_reporting',
 					'Sift Debug & Reporting Settings'
 				),
 
-				$this->create_element(
+				$this->html->create_element(
 					WC_SiftScience_Html::WC_CUSTOM_ELEMENT,
 					'anon_id',
 					'Anonymous ID',
 					$this->get_anon_id_content()
 				),
 
-				$this->create_element(
+				$this->html->create_element(
 					WC_SiftScience_Html::WC_CHECKBOX_ELEMENT,
 					WC_SiftScience_Options::SEND_STATS,
 					'Enable Reporting',
@@ -276,7 +276,7 @@ if ( ! class_exists( 'WC_SiftScience_Admin' ) ) :
 					array( 'desc_tip' => $this->get_reporting_checkbox_description() )
 				),
 
-				$this->create_element(
+				$this->html->create_element(
 					WC_SiftScience_Html::WC_SELECT_ELEMENT,
 					WC_SiftScience_Options::LOG_LEVEL_KEY,
 					'Log Level',
@@ -291,7 +291,7 @@ if ( ! class_exists( 'WC_SiftScience_Admin' ) ) :
 					)
 				),
 
-				$this->create_element(
+				$this->html->create_element(
 					WC_SiftScience_Html::WC_SECTIONEND_ELEMENT,
 					'sifsci_section_reporting'
 				),
@@ -341,27 +341,27 @@ if ( ! class_exists( 'WC_SiftScience_Admin' ) ) :
 		 */
 		private function get_settings_main() {
 			return array(
-				$this->create_element(
+				$this->html->create_element(
 					WC_SiftScience_Html::WC_TITLE_ELEMENT,
 					'siftsci_title_id',
 					'Sift Settings'
 				),
 
-				$this->create_element(
+				$this->html->create_element(
 					WC_SiftScience_Html::WC_TEXT_ELEMENT,
 					WC_SiftScience_Options::API_KEY,
 					'Rest API Key',
 					'The API key for production'
 				),
 
-				$this->create_element(
+				$this->html->create_element(
 					WC_SiftScience_Html::WC_TEXT_ELEMENT,
 					WC_SiftScience_Options::JS_KEY,
 					'Javascript Snippet Key',
 					'Javascript snippet key for production'
 				),
 
-				$this->create_element(
+				$this->html->create_element(
 					WC_SiftScience_Html::WC_NUMBER_ELEMENT,
 					WC_SiftScience_Options::THRESHOLD_GOOD,
 					'Good Score Threshold',
@@ -376,7 +376,7 @@ if ( ! class_exists( 'WC_SiftScience_Admin' ) ) :
 					)
 				),
 
-				$this->create_element(
+				$this->html->create_element(
 					WC_SiftScience_Html::WC_NUMBER_ELEMENT,
 					WC_SiftScience_Options::THRESHOLD_BAD,
 					'Bad Score Threshold',
@@ -390,7 +390,7 @@ if ( ! class_exists( 'WC_SiftScience_Admin' ) ) :
 						'desc_tip' => true,
 					)
 				),
-				$this->create_element(
+				$this->html->create_element(
 					WC_SiftScience_Html::WC_TEXT_ELEMENT,
 					WC_SiftScience_Options::NAME_PREFIX,
 					'User & Order Name Prefix',
@@ -398,14 +398,14 @@ if ( ! class_exists( 'WC_SiftScience_Admin' ) ) :
 					array( 'desc_tip' => 'Useful when you have have multiple stores and one Sift account.' )
 				),
 
-				$this->create_element(
+				$this->html->create_element(
 					WC_SiftScience_Html::WC_CHECKBOX_ELEMENT,
 					WC_SiftScience_Options::AUTO_SEND_ENABLED,
 					'Automatically Send Data',
 					'Automatically send data to Sift when an order is created'
 				),
 
-				$this->create_element(
+				$this->html->create_element(
 					WC_SiftScience_Html::WC_NUMBER_ELEMENT,
 					WC_SiftScience_Options::MIN_ORDER_VALUE,
 					'Auto Send Minimum Value',
@@ -419,125 +419,11 @@ if ( ! class_exists( 'WC_SiftScience_Admin' ) ) :
 					)
 				),
 
-				$this->create_element(
+				$this->html->create_element(
 					WC_SiftScience_Html::WC_SECTIONEND_ELEMENT,
 					'sifsci_section_main'
 				),
 			);
-		}
-
-		public function __call( $name, $args ) {
-			if ( 'WC_SiftScience_Admin::create_element' === $name ) {
-
-				echo 'ra ra ra';
-				switch ( count( $args ) ) {
-					case 2:
-						return $this->create_element( $args[0], $args[1], '', '', array() );
-					case 3:
-						return $this->create_element( $args[0], $args[1], $args[2], '', array() );
-					case 4:
-						return $this->create_element( $args[0], $args[1], $args[2], $args[3], array() );
-					case 5:
-						return $this->create_element( $args[0], $args[1], $args[2], $args[3], $args[4] );
-					default:
-						$this->logger->log_error( 'there is no delaretion method for create_element with ' . count( $args ) . ' arguemnts' );
-						break;
-				}
-			}
-		}
-
-		/**
-		 * This function sets HTML element attributes according to woocommearce provided library.
-		 * desc_tip Mixed [bool:false] (default)
-		 *     field type of checkbox; the desc text is going next to the control
-		 *     field type of select, number or text; the desc text is going underneath control
-		 * desc_tip Mixed [bool:true]
-		 *     [X] field type of checkbox; the desc text is going underneath control
-		 *     field type of select, number or text; a question mark pop-up appears before control with desc text
-		 * desc_tip Mixed [string]
-		 *     field type of checkbox; the desc_tip text is going underneath control
-		 *     field type of select, number or text; a question mark pop-up appears before control with desc_tip text
-		 * NOTE: if desc_tip isn't a string and it's a checkbox [X] disc_tip is sanitized to false, add it in element_options
-		 *
-		 * @param string $type            Element type name.
-		 * @param string $id              HtmlElement ID.
-		 * @param string $label           Element label.
-		 * @param string $desc            Description text.
-		 * @param array  $element_options Element special options.
-		 *
-		 * @return array $element         An array of attributes.
-		 * @since 1.1.0
-		 */
-		private function create_element( $type, $id, $labe, $desc, $element_options ) {
-
-			if ( WC_SiftScience_Html::WC_SELECT_ELEMENT === $type ) {
-				if ( ! isset( $element_options['options'] ) || empty( $element_options['options'] ) ) {
-					$this->logger->log_error( 'Drop down ' . $id . ' cannot be empty!' );
-					return;
-				}
-			}
-
-			$element = array();
-			// array flattener.
-			$custom_attributes =
-			array(
-				'min'  => '',
-				'max'  => '',
-				'step' => '',
-			);
-			$custom_attributes = array_intersect_key( $element_options, $custom_attributes ); // Gets the new values.
-
-			if ( ! empty( $custom_attributes ) ) {
-				$element = array_diff_key( $element_options, $custom_attributes ); // Unsets those specific keys.
-
-				$element['custom_attributes'] = $custom_attributes; // Add the Flaterned version.
-			}
-
-			if ( isset( $element_options['desc_tip'] ) ) {
-				$desc_tip = $element_options['desc_tip'];
-				if ( WC_SiftScience_Html::WC_CHECKBOX_ELEMENT === $type ) {
-					$element_options['desc_tip'] = ( is_string( $desc_tip ) && ! empty( $desc_tip ) ) ? $desc_tip : false;
-					// desc_tip sanitized from being true or not being a stirng.
-				}
-			}
-
-			switch ( $type ) {
-				case WC_SiftScience_Html::WC_CUSTOM_ELEMENT:
-					$type     = 'wc_sift_' . $id; // this is the custom type name needed by WooCommerce.
-					$callback = array( $this->html, 'display_custom_settings_row' );
-					add_action( 'woocommerce_admin_field_' . $type, $callback );
-					// This intentionally falls through to the next section.
-
-				case WC_SiftScience_Html::WC_CHECKBOX_ELEMENT:
-				case WC_SiftScience_Html::WC_NUMBER_ELEMENT:
-				case WC_SiftScience_Html::WC_TEXT_ELEMENT:
-				case WC_SiftScience_Html::WC_SELECT_ELEMENT:
-					if ( ! empty( $element_options ) ) {
-						$element = array_merge( $element, $element_options );
-					}
-					// $element_options added.
-
-				case WC_SiftScience_Html::WC_TITLE_ELEMENT:
-					if ( ! empty( $desc ) ) {
-						$element['desc'] = $desc;
-					}
-
-					if ( ! empty( $label ) ) {
-						$element['title'] = $label;
-					}
-					// Title and description are added all What's left [id and type].
-
-				case WC_SiftScience_Html::WC_SECTIONEND_ELEMENT:
-					$element['id']   = $id;
-					$element['type'] = $type;
-					break;
-
-				default:
-					$this->logger->log_error( $type . ' is not a valid type!' );
-					break;
-			}
-
-			return $element;
 		}
 
 		/**

--- a/includes/class-wc-siftscience-admin.php
+++ b/includes/class-wc-siftscience-admin.php
@@ -315,7 +315,7 @@ if ( ! class_exists( 'WC_SiftScience_Admin' ) ) :
 					}
 					break;
 				case 'reporting':
-					WC_Admin_Settings::save_fields( $this->get_settings_stats() );
+					WC_Admin_Settings::save_fields( $this->get_settings_reporting() );
 					break;
 				default:
 					break;

--- a/includes/class-wc-siftscience-html.php
+++ b/includes/class-wc-siftscience-html.php
@@ -60,7 +60,7 @@ if ( ! class_exists( 'WC_SiftScience_Html' ) ) :
 						return;
 					}
 				}
-				if ( isset( $args[2] ) && ! enpty( $args[2] ) ) {
+				if ( isset( $args[2] ) && empty( $args[2] ) ) {
 					$args[2] = '[Empty lable]';
 				}
 

--- a/includes/class-wc-siftscience-html.php
+++ b/includes/class-wc-siftscience-html.php
@@ -144,11 +144,12 @@ if ( ! class_exists( 'WC_SiftScience_Html' ) ) :
 				case self::WC_TITLE_ELEMENT:
 				case self::WC_NUMBER_ELEMENT:
 				case self::WC_SELECT_ELEMENT:
-				case self::WC_CHECKBOX_ELEMENT:
-					$element_options['desc']     = $desc;
-					$element_options['title']    = $label;
 					$element_options['desc_tip'] = $desc_tip;
-					// Title, desc and desc_tip are added all What's left [id and type].
+					// desc_tip is added.
+				case self::WC_CHECKBOX_ELEMENT:
+					$element_options['desc']  = $desc;
+					$element_options['title'] = $label;
+					// Title and desc are added all What's left [id and type].
 
 				case self::WC_SECTIONEND_ELEMENT:
 					$element_options['id']   = $id;

--- a/includes/class-wc-siftscience-html.php
+++ b/includes/class-wc-siftscience-html.php
@@ -98,7 +98,7 @@ if ( ! class_exists( 'WC_SiftScience_Html' ) ) :
 			switch ( $type ) {
 				case self::WC_CUSTOM_ELEMENT:
 					$type     = 'wc_sift_' . $id; // this is the custom type name needed by WooCommerce.
-					$callback = array( $this->html, 'display_custom_settings_row' );
+					$callback = array( $this, 'display_custom_settings_row' );
 					add_action( 'woocommerce_admin_field_' . $type, $callback );
 					// This intentionally falls through to the next section.
 

--- a/includes/class-wc-siftscience-html.php
+++ b/includes/class-wc-siftscience-html.php
@@ -53,18 +53,26 @@ if ( ! class_exists( 'WC_SiftScience_Html' ) ) :
 		 */
 		public function __call( $name, $args ) {
 			if ( 'create_element' === $name ) {
-				// if type id delect amd options array empty element wont create.
+				// element type of select must add options array to it's call.
 				if ( self::WC_SELECT_ELEMENT === $args[1] ) {
 					if ( ! isset( $args[4]['options'] ) || empty( $args[4]['options'] || ! is_array( $args[4]['options'] ) ) ) {
 						$this->logger->log_error( 'Drop down ' . $id . ' cannot be empty!' );
 						return;
 					}
 				}
-				if ( isset( $args[2] ) && empty( $args[2] ) ) {
-					$args[2] = '[Empty lable]';
+				$arguments_count = count( $args );
+				if ( 2 < $arguments_count ) { // Label is sent empty.
+					if ( isset( $args[2] ) && empty( $args[2] ) ) {
+						$args[2] = '[Empty lable]';
+					}
+					if ( 3 < $arguments_count ) { // description is sent empty.
+						if ( isset( $args[3] ) && empty( $args[3] ) ) {
+							$args[3] = '[Empty description]';
+						}
+					}
 				}
 
-				switch ( count( $args ) ) {
+				switch ( $arguments_count ) {
 					case 2:
 						return $this->create_element( $args[0], $args[1], '', '', false, array() );
 					case 3:

--- a/includes/class-wc-siftscience-html.php
+++ b/includes/class-wc-siftscience-html.php
@@ -148,7 +148,7 @@ if ( ! class_exists( 'WC_SiftScience_Html' ) ) :
 					$element_options['desc']     = $desc;
 					$element_options['title']    = $label;
 					$element_options['desc_tip'] = $desc_tip;
-					// Title and description are added all What's left [id and type].
+					// Title, desc and desc_tip are added all What's left [id and type].
 
 				case self::WC_SECTIONEND_ELEMENT:
 					$element_options['id']   = $id;

--- a/includes/class-wc-siftscience-html.php
+++ b/includes/class-wc-siftscience-html.php
@@ -44,47 +44,25 @@ if ( ! class_exists( 'WC_SiftScience_Html' ) ) :
 		}
 
 		/**
-		 * This function validates and sanitizes calls for create_element
-		 *
-		 * @see WC_SiftScience_Html::create_element
+		 * This function manages the call from outside [admin class] overloading creqate element
 		 *
 		 * @param string $name the method name create_element.
 		 * @param Array  $args the arguments provided.
 		 */
 		public function __call( $name, $args ) {
 			if ( 'create_element' === $name ) {
-				// if type id delect amd options array empty element wont create.
-				if ( self::WC_SELECT_ELEMENT === $args[1] ) {
-					if ( ! isset( $args[4]['options'] ) || empty( $args[4]['options'] || ! is_array( $args[4]['options'] ) ) ) {
-						$this->logger->log_error( 'Drop down ' . $id . ' cannot be empty!' );
-						return;
-					}
-				}
-				if ( isset( $args[2] ) && ! enpty( $args[2] ) ) {
-					$args[2] = '[Empty lable]';
-				}
 
 				switch ( count( $args ) ) {
 					case 2:
-						return $this->create_element( $args[0], $args[1], '', '', false, array() );
+						return $this->create_element( $args[0], $args[1], '', '', array() );
 					case 3:
-						return $this->create_element( $args[0], $args[1], $args[2], '', false, array() );
+						return $this->create_element( $args[0], $args[1], $args[2], '', array() );
 					case 4:
-						return $this->create_element( $args[0], $args[1], $args[2], $args[3], false, array() );
+						return $this->create_element( $args[0], $args[1], $args[2], $args[3], array() );
 					case 5:
-						if ( isset( $args[4]['desc_tip'] ) ) {
-							if ( self::WC_CHECKBOX_ELEMENT === $args[1] ) {
-								// if desc_tip is not a string or empty it sanitized to false.
-								$desc_tip = ( is_string( $args[4]['desc_tip'] ) && ! empty( $args[4]['desc_tip'] ) ) ? $args[4]['desc_tip'] : false;
-							} else {
-								$desc_tip = $args[4]['desc_tip'];
-							}
-							return $this->create_element( $args[0], $args[1], $args[2], $args[3], $desc_tip, $args[4] );
-						} else {
-							return $this->create_element( $args[0], $args[1], $args[2], $args[3], false, $args[4] );
-						}
+						return $this->create_element( $args[0], $args[1], $args[2], $args[3], $args[4] );
 					default:
-						$this->logger->log_error( 'There is no delaretion method for create_element with ' . count( $args ) . ' arguemnts' );
+						$this->logger->log_error( 'there is no delaretion method for create_element with ' . count( $args ) . ' arguemnts' );
 						break;
 				}
 			}
@@ -101,21 +79,37 @@ if ( ! class_exists( 'WC_SiftScience_Html' ) ) :
 		 * desc_tip Mixed [string]
 		 *     field type of checkbox; the desc_tip text is going underneath control
 		 *     field type of select, number or text; a question mark pop-up appears before control with desc_tip text
-		 * desc_rip is added in element options.
+		 * NOTE: if desc_tip isn't a string and it's a checkbox [X] disc_tip is sanitized to false, add it in element_options
 		 *
 		 * @param string $type            Element type name.
 		 * @param string $id              HtmlElement ID.
 		 * @param string $label           Element label.
 		 * @param string $desc            Description text.
-		 * @param mixed  $desc_tip        description tip.
 		 * @param array  $element_options Element special options.
 		 *
 		 * @return array $element         An array of attributes.
 		 * @since 1.1.0
 		 */
-		private function create_element( $type, $id, $label, $desc, $desc_tip, $element_options ) {
+		private function create_element( $type, $id, $label, $desc, $element_options ) {
 
-			$element = array();
+			if ( self::WC_SELECT_ELEMENT === $type ) {
+				if ( ! isset( $element_options['options'] ) || empty( $element_options['options'] ) ) {
+					$this->logger->log_error( 'Drop down ' . $id . ' cannot be empty!' );
+					return;
+				}
+			}
+
+			$element  = array();
+			$desc_tip = false;
+			if ( isset( $element_options['desc_tip'] ) ) {
+				$desc_tip = $element_options['desc_tip'];
+				unset( $element_options['desc_tip'] );
+				if ( self::WC_CHECKBOX_ELEMENT === $type ) {
+					$desc_tip = ( is_string( $desc_tip ) && ! empty( $desc_tip ) ) ? $desc_tip : false;
+					// desc_tip sanitized from being true or not being a stirng to false.
+				}
+			}
+
 			switch ( $type ) {
 				case self::WC_CUSTOM_ELEMENT:
 					$type     = 'wc_sift_' . $id; // this is the custom type name needed by WooCommerce.

--- a/includes/class-wc-siftscience-html.php
+++ b/includes/class-wc-siftscience-html.php
@@ -84,13 +84,14 @@ if ( ! class_exists( 'WC_SiftScience_Html' ) ) :
 				}
 			}
 
-			$element = array();
-
+			$element  = array();
+			$desc_tip = false;
 			if ( isset( $element_options['desc_tip'] ) ) {
 				$desc_tip = $element_options['desc_tip'];
+				unset( $element_options['desc_tip'] );
 				if ( self::WC_CHECKBOX_ELEMENT === $type ) {
-					$element_options['desc_tip'] = ( is_string( $desc_tip ) && ! empty( $desc_tip ) ) ? $desc_tip : false;
-					// desc_tip sanitized from being true or not being a stirng.
+					$desc_tip = ( is_string( $desc_tip ) && ! empty( $desc_tip ) ) ? $desc_tip : false;
+					// desc_tip sanitized from being true or not being a stirng to false.
 				}
 			}
 
@@ -120,13 +121,9 @@ if ( ! class_exists( 'WC_SiftScience_Html' ) ) :
 					// $element_options added.
 
 				case self::WC_TITLE_ELEMENT:
-					if ( ! empty( $desc ) ) {
-						$element['desc'] = $desc;
-					}
-
-					if ( ! empty( $label ) ) {
-						$element['title'] = $label;
-					}
+					$element['desc']     = $desc;
+					$element['title']    = $label;
+					$element['desc_tip'] = $desc_tip;
 					// Title and description are added all What's left [id and type].
 
 				case self::WC_SECTIONEND_ELEMENT:

--- a/includes/class-wc-siftscience-html.php
+++ b/includes/class-wc-siftscience-html.php
@@ -134,29 +134,25 @@ if ( ! class_exists( 'WC_SiftScience_Html' ) ) :
 		 */
 		private function create_element( $type, $id, $label, $desc, $desc_tip, $element_options ) {
 
-			$element = array();
 			switch ( $type ) {
 				case self::WC_CUSTOM_ELEMENT:
 					$type = 'wc_sift_' . $id; // this is the custom type name needed by WooCommerce.
 					add_action( 'woocommerce_admin_field_' . $type, array( $this, 'display_custom_settings_row' ) );
 					// This intentionally falls through to the next section.
 
-				case self::WC_CHECKBOX_ELEMENT:
-				case self::WC_NUMBER_ELEMENT:
 				case self::WC_TEXT_ELEMENT:
-				case self::WC_SELECT_ELEMENT:
-					$element = array_merge( $element, $element_options );
-					// $element_options added.
-
 				case self::WC_TITLE_ELEMENT:
-					$element['desc']     = $desc;
-					$element['title']    = $label;
-					$element['desc_tip'] = $desc_tip;
+				case self::WC_NUMBER_ELEMENT:
+				case self::WC_SELECT_ELEMENT:
+				case self::WC_CHECKBOX_ELEMENT:
+					$element_options['desc']     = $desc;
+					$element_options['title']    = $label;
+					$element_options['desc_tip'] = $desc_tip;
 					// Title and description are added all What's left [id and type].
 
 				case self::WC_SECTIONEND_ELEMENT:
-					$element['id']   = $id;
-					$element['type'] = $type;
+					$element_options['id']   = $id;
+					$element_options['type'] = $type;
 					break;
 
 				default:
@@ -164,7 +160,7 @@ if ( ! class_exists( 'WC_SiftScience_Html' ) ) :
 					break;
 			}
 
-			return $element;
+			return $element_options;
 		}
 
 		/**

--- a/includes/class-wc-siftscience-html.php
+++ b/includes/class-wc-siftscience-html.php
@@ -76,11 +76,11 @@ if ( ! class_exists( 'WC_SiftScience_Html' ) ) :
 
 				switch ( count( $args ) ) {
 					case 2:
-						return $this->create_element( $args[0], $args[1], '', '', false, array() );
+						return $this->create_element( $args[0], $args[1], '', '', array() );
 					case 3:
-						return $this->create_element( $args[0], $args[1], $args[2], '', false, array() );
+						return $this->create_element( $args[0], $args[1], $args[2], '', array() );
 					case 4:
-						return $this->create_element( $args[0], $args[1], $args[2], $args[3], false, array() );
+						return $this->create_element( $args[0], $args[1], $args[2], $args[3], array() );
 					case 5:
 						// array flattener.
 						$custom_attributes = array( 'min', 'max', 'step' );
@@ -94,13 +94,9 @@ if ( ! class_exists( 'WC_SiftScience_Html' ) ) :
 						if ( isset( $args[4]['desc_tip'] ) ) {
 							if ( self::WC_CHECKBOX_ELEMENT === $args[1] ) {
 								// if desc_tip is not a string or empty it sanitized to false.
-								$desc_tip = ( is_string( $args[4]['desc_tip'] ) && ! empty( $args[4]['desc_tip'] ) ) ? $args[4]['desc_tip'] : false;
-							} else {
-								$desc_tip = $args[4]['desc_tip'];
+								$args[4]['desc_tip'] = ( is_string( $args[4]['desc_tip'] ) && ! empty( $args[4]['desc_tip'] ) ) ? $args[4]['desc_tip'] : false;
 							}
-							return $this->create_element( $args[0], $args[1], $args[2], $args[3], $desc_tip, $args[4] );
-						} else {
-							return $this->create_element( $args[0], $args[1], $args[2], $args[3], false, $args[4] );
+							return $this->create_element( $args[0], $args[1], $args[2], $args[3], $args[4] );
 						}
 					default:
 						$this->logger->log_error( 'There is no delaretion method for create_element with ' . count( $args ) . ' arguemnts' );
@@ -126,13 +122,12 @@ if ( ! class_exists( 'WC_SiftScience_Html' ) ) :
 		 * @param string $id              HtmlElement ID.
 		 * @param string $label           Element label.
 		 * @param string $desc            Description text.
-		 * @param mixed  $desc_tip        description tip.
 		 * @param array  $element_options Element special options.
 		 *
 		 * @return array $element         An array of attributes.
 		 * @since 1.1.0
 		 */
-		private function create_element( $type, $id, $label, $desc, $desc_tip, $element_options ) {
+		private function create_element( $type, $id, $label, $desc, $element_options ) {
 
 			switch ( $type ) {
 				case self::WC_CUSTOM_ELEMENT:
@@ -144,8 +139,6 @@ if ( ! class_exists( 'WC_SiftScience_Html' ) ) :
 				case self::WC_SELECT_ELEMENT:
 				case self::WC_NUMBER_ELEMENT:
 				case self::WC_CHECKBOX_ELEMENT:
-					$element_options['desc_tip'] = $desc_tip;
-					// desc_tip is added.
 				case self::WC_TITLE_ELEMENT:
 					$element_options['desc']  = $desc;
 					$element_options['title'] = $label;

--- a/includes/class-wc-siftscience-html.php
+++ b/includes/class-wc-siftscience-html.php
@@ -61,10 +61,10 @@ if ( ! class_exists( 'WC_SiftScience_Html' ) ) :
 					}
 				}
 
-				if ( isset( $args[2] ) && empty( $args[2] ) ) { // Label is sent empty.
+				if ( isset( $args[2] ) && empty( $args[2] ) ) { // Label is empty.
 					$args[2] = '[Empty lable]';
 
-					if ( isset( $args[3] ) && empty( $args[3] ) ) { // description is sent empty.
+					if ( isset( $args[3] ) && empty( $args[3] ) ) { // description is empty.
 							$args[3] = '[Empty description]';
 					}
 				}

--- a/includes/class-wc-siftscience-html.php
+++ b/includes/class-wc-siftscience-html.php
@@ -141,12 +141,12 @@ if ( ! class_exists( 'WC_SiftScience_Html' ) ) :
 					// This intentionally falls through to the next section.
 
 				case self::WC_TEXT_ELEMENT:
-				case self::WC_TITLE_ELEMENT:
-				case self::WC_NUMBER_ELEMENT:
 				case self::WC_SELECT_ELEMENT:
+				case self::WC_NUMBER_ELEMENT:
+				case self::WC_CHECKBOX_ELEMENT:
 					$element_options['desc_tip'] = $desc_tip;
 					// desc_tip is added.
-				case self::WC_CHECKBOX_ELEMENT:
+				case self::WC_TITLE_ELEMENT:
 					$element_options['desc']  = $desc;
 					$element_options['title'] = $label;
 					// Title and desc are added all What's left [id and type].

--- a/includes/class-wc-siftscience-html.php
+++ b/includes/class-wc-siftscience-html.php
@@ -19,6 +19,12 @@ if ( ! class_exists( 'WC_SiftScience_Html' ) ) :
 	 * Class WC_SiftScience_Html
 	 */
 	class WC_SiftScience_Html {
+		/**
+		 * The logger service
+		 *
+		 * @var WC_SiftScience_Logger
+		 */
+		private $logger;
 
 		public const WC_TITLE_ELEMENT      = 'title';
 		public const WC_TEXT_ELEMENT       = 'text';
@@ -27,6 +33,15 @@ if ( ! class_exists( 'WC_SiftScience_Html' ) ) :
 		public const WC_CHECKBOX_ELEMENT   = 'checkbox';
 		public const WC_SECTIONEND_ELEMENT = 'sectionend';
 		public const WC_CUSTOM_ELEMENT     = 'custom';
+
+		/**
+		 * WC_SiftScience_Html constructor.
+		 *
+		 * @param WC_SiftScience_Logger $logger Logger service.
+		 */
+		public function __construct( WC_SiftScience_Logger $logger ) {
+			$this->logger = $logger;
+		}
 
 		/**
 		 * This function manages the call from outside [admin class] overloading creqate element

--- a/includes/class-wc-siftscience-html.php
+++ b/includes/class-wc-siftscience-html.php
@@ -60,19 +60,16 @@ if ( ! class_exists( 'WC_SiftScience_Html' ) ) :
 						return;
 					}
 				}
-				$arguments_count = count( $args );
-				if ( 2 < $arguments_count ) { // Label is sent empty.
-					if ( isset( $args[2] ) && empty( $args[2] ) ) {
-						$args[2] = '[Empty lable]';
-					}
-					if ( 3 < $arguments_count ) { // description is sent empty.
-						if ( isset( $args[3] ) && empty( $args[3] ) ) {
+
+				if ( isset( $args[2] ) && empty( $args[2] ) ) { // Label is sent empty.
+					$args[2] = '[Empty lable]';
+
+					if ( isset( $args[3] ) && empty( $args[3] ) ) { // description is sent empty.
 							$args[3] = '[Empty description]';
-						}
 					}
 				}
 
-				switch ( $arguments_count ) {
+				switch ( count( $args ) ) {
 					case 2:
 						return $this->create_element( $args[0], $args[1], '', '', false, array() );
 					case 3:

--- a/includes/class-wc-siftscience-html.php
+++ b/includes/class-wc-siftscience-html.php
@@ -44,25 +44,47 @@ if ( ! class_exists( 'WC_SiftScience_Html' ) ) :
 		}
 
 		/**
-		 * This function manages the call from outside [admin class] overloading creqate element
+		 * This function validates and sanitizes calls for create_element
+		 *
+		 * @see WC_SiftScience_Html::create_element
 		 *
 		 * @param string $name the method name create_element.
 		 * @param Array  $args the arguments provided.
 		 */
 		public function __call( $name, $args ) {
 			if ( 'create_element' === $name ) {
+				// if type id delect amd options array empty element wont create.
+				if ( self::WC_SELECT_ELEMENT === $args[1] ) {
+					if ( ! isset( $args[4]['options'] ) || empty( $args[4]['options'] || ! is_array( $args[4]['options'] ) ) ) {
+						$this->logger->log_error( 'Drop down ' . $id . ' cannot be empty!' );
+						return;
+					}
+				}
+				if ( isset( $args[2] ) && ! enpty( $args[2] ) ) {
+					$args[2] = '[Empty lable]';
+				}
 
 				switch ( count( $args ) ) {
 					case 2:
-						return $this->create_element( $args[0], $args[1], '', '', array() );
+						return $this->create_element( $args[0], $args[1], '', '', false, array() );
 					case 3:
-						return $this->create_element( $args[0], $args[1], $args[2], '', array() );
+						return $this->create_element( $args[0], $args[1], $args[2], '', false, array() );
 					case 4:
-						return $this->create_element( $args[0], $args[1], $args[2], $args[3], array() );
+						return $this->create_element( $args[0], $args[1], $args[2], $args[3], false, array() );
 					case 5:
-						return $this->create_element( $args[0], $args[1], $args[2], $args[3], $args[4] );
+						if ( isset( $args[4]['desc_tip'] ) ) {
+							if ( self::WC_CHECKBOX_ELEMENT === $args[1] ) {
+								// if desc_tip is not a string or empty it sanitized to false.
+								$desc_tip = ( is_string( $args[4]['desc_tip'] ) && ! empty( $args[4]['desc_tip'] ) ) ? $args[4]['desc_tip'] : false;
+							} else {
+								$desc_tip = $args[4]['desc_tip'];
+							}
+							return $this->create_element( $args[0], $args[1], $args[2], $args[3], $desc_tip, $args[4] );
+						} else {
+							return $this->create_element( $args[0], $args[1], $args[2], $args[3], false, $args[4] );
+						}
 					default:
-						$this->logger->log_error( 'there is no delaretion method for create_element with ' . count( $args ) . ' arguemnts' );
+						$this->logger->log_error( 'There is no delaretion method for create_element with ' . count( $args ) . ' arguemnts' );
 						break;
 				}
 			}
@@ -79,37 +101,21 @@ if ( ! class_exists( 'WC_SiftScience_Html' ) ) :
 		 * desc_tip Mixed [string]
 		 *     field type of checkbox; the desc_tip text is going underneath control
 		 *     field type of select, number or text; a question mark pop-up appears before control with desc_tip text
-		 * NOTE: if desc_tip isn't a string and it's a checkbox [X] disc_tip is sanitized to false, add it in element_options
+		 * desc_rip is added in element options.
 		 *
 		 * @param string $type            Element type name.
 		 * @param string $id              HtmlElement ID.
 		 * @param string $label           Element label.
 		 * @param string $desc            Description text.
+		 * @param mixed  $desc_tip        description tip.
 		 * @param array  $element_options Element special options.
 		 *
 		 * @return array $element         An array of attributes.
 		 * @since 1.1.0
 		 */
-		private function create_element( $type, $id, $label, $desc, $element_options ) {
+		private function create_element( $type, $id, $label, $desc, $desc_tip, $element_options ) {
 
-			if ( self::WC_SELECT_ELEMENT === $type ) {
-				if ( ! isset( $element_options['options'] ) || empty( $element_options['options'] ) ) {
-					$this->logger->log_error( 'Drop down ' . $id . ' cannot be empty!' );
-					return;
-				}
-			}
-
-			$element  = array();
-			$desc_tip = false;
-			if ( isset( $element_options['desc_tip'] ) ) {
-				$desc_tip = $element_options['desc_tip'];
-				unset( $element_options['desc_tip'] );
-				if ( self::WC_CHECKBOX_ELEMENT === $type ) {
-					$desc_tip = ( is_string( $desc_tip ) && ! empty( $desc_tip ) ) ? $desc_tip : false;
-					// desc_tip sanitized from being true or not being a stirng to false.
-				}
-			}
-
+			$element = array();
 			switch ( $type ) {
 				case self::WC_CUSTOM_ELEMENT:
 					$type     = 'wc_sift_' . $id; // this is the custom type name needed by WooCommerce.

--- a/includes/class-wc-siftscience-html.php
+++ b/includes/class-wc-siftscience-html.php
@@ -27,7 +27,13 @@ if ( ! class_exists( 'WC_SiftScience_Html' ) ) :
 		public const WC_CHECKBOX_ELEMENT   = 'checkbox';
 		public const WC_SECTIONEND_ELEMENT = 'sectionend';
 		public const WC_CUSTOM_ELEMENT     = 'custom';
-		
+
+		/**
+		 * This function manages the call from outside [admin class] overloading creqate element
+		 *
+		 * @param string $name the method name create_element.
+		 * @param Array  $args the arguments provided.
+		 */
 		public function __call( $name, $args ) {
 			if ( 'create_element' === $name ) {
 
@@ -79,20 +85,6 @@ if ( ! class_exists( 'WC_SiftScience_Html' ) ) :
 			}
 
 			$element = array();
-			// array flattener.
-			$custom_attributes =
-			array(
-				'min'  => '',
-				'max'  => '',
-				'step' => '',
-			);
-			$custom_attributes = array_intersect_key( $element_options, $custom_attributes ); // Gets the new values.
-
-			if ( ! empty( $custom_attributes ) ) {
-				$element = array_diff_key( $element_options, $custom_attributes ); // Unsets those specific keys.
-
-				$element['custom_attributes'] = $custom_attributes; // Add the Flaterned version.
-			}
 
 			if ( isset( $element_options['desc_tip'] ) ) {
 				$desc_tip = $element_options['desc_tip'];
@@ -114,6 +106,15 @@ if ( ! class_exists( 'WC_SiftScience_Html' ) ) :
 				case self::WC_TEXT_ELEMENT:
 				case self::WC_SELECT_ELEMENT:
 					if ( ! empty( $element_options ) ) {
+						// array flattener.
+						$custom_attributes = array( 'min', 'max', 'step' );
+						$custom_attributes = array_intersect_key( $element_options, array_flip( $custom_attributes ) ); // Gets the new values.
+
+						if ( ! empty( $custom_attributes ) ) {
+							$element_options = array_diff_key( $element_options, $custom_attributes ); // Unsets those specific keys.
+
+							$element_options['custom_attributes'] = $custom_attributes; // sets array level 2.
+						}
 						$element = array_merge( $element, $element_options );
 					}
 					// $element_options added.


### PR DESCRIPTION
- custom attributes logic should get merged into case statement 
 there is no point doing this for every call 

-  all elements differences should be overloaded 

1. title must have a title and may have a desc and may also have  desc_tip

2. all other elements must have a description  
