### PR TITLE
copy button text changes

### DIFF
--- a/dist/js/copy.js
+++ b/dist/js/copy.js
@@ -1,8 +1,10 @@
-sender = null;
+window._wc_siftsci_js_sender = null;
 function copyInfo( source, elementId ) {
+	
+	var sender = window._wc_siftsci_js_sender;
 	if( null === sender || void 0 === sender ) {
+		sender       = source;
 		source.title = 'Copied';
-		sender = source;
 	} else {
 		sender.title = 'Copy to clipboard';
 	}

--- a/dist/js/copy.js
+++ b/dist/js/copy.js
@@ -3,7 +3,7 @@ function copyInfo( source, elementId ) {
 
 	var sender = window._wc_siftsci_js_sender;
 
-	if( null != sender || void 0 != sender ) {
+	if( null !== sender ) {
 		sender.title = 'Copy to clipboard';
 	}
 	

--- a/dist/js/copy.js
+++ b/dist/js/copy.js
@@ -1,13 +1,13 @@
 window._wc_siftsci_js_sender = null;
 function copyInfo( source, elementId ) {
-	
+
 	var sender = window._wc_siftsci_js_sender;
-	if( null === sender || void 0 === sender ) {
-		sender       = source;
-		source.title = 'Copied';
-	} else {
+
+	if( null != sender || void 0 != sender ) {
 		sender.title = 'Copy to clipboard';
 	}
+	
+	window._wc_siftsci_js_sender = source;
 
 	var element = document.getElementById( elementId );
 

--- a/dist/js/copy.js
+++ b/dist/js/copy.js
@@ -1,8 +1,17 @@
-function copyInfo( elementId ) {
-  var element = document.getElementById( elementId );
+sender = null;
+function copyInfo( source, elementId ) {
+	if( null === sender || void 0 === sender ) {
+		source.title = 'Copied';
+		sender = source;
+	} else {
+		sender.title = 'Copy to clipboard';
+	}
 
-  element.select();
-  document.execCommand( 'copy' );
-  
-  element.setSelectionRange( 0, 0 ); // Clear selection.
+	var element = document.getElementById( elementId );
+
+	element.select();
+	document.execCommand( 'copy' );
+
+	element.setSelectionRange( 0, 0 ); // Clear selection.
+	source.title = 'Copied';
 }

--- a/includes/class-wc-siftscience-html.php
+++ b/includes/class-wc-siftscience-html.php
@@ -171,7 +171,7 @@ if ( ! class_exists( 'WC_SiftScience_Html' ) ) :
 					?>
 					<img 
 						alt="" 
-						onclick="copyInfo('debugLog')" 
+						onclick="copyInfo( this, 'debugLog' )" 
 						title="Copy to clipboard" 
 						src="<?php echo esc_url( $clipboard_img_src ); ?>" 
 					/>
@@ -192,7 +192,7 @@ if ( ! class_exists( 'WC_SiftScience_Html' ) ) :
 					?>
 				<img 
 					alt="" 
-					onclick="copyInfo('debugSSL')" 
+					onclick="copyInfo( this, 'debugSSL' )" 
 					title="Copy to clipboard" 
 					src="<?php echo esc_url( $clipboard_img_src ); ?>" 
 				/>


### PR DESCRIPTION
We have ‘2 copy buttons’ but didn’t have textual representation for notification purposes

In short: now img title toggles between copy and copied regarding business needs suing sender ‘a global Javascript var’