### PR TITLE
a go-a-round

### DIFF
--- a/includes/class-wc-siftscience-element.php
+++ b/includes/class-wc-siftscience-element.php
@@ -108,7 +108,9 @@ if ( ! class_exists( 'WC_SiftScience_Element' ) ) :
 			switch ( $type ) {
 				case self::CUSTOM:
 					$type = 'wc_sift_' . $id; // this is the custom type name needed by WooCommerce.
-					add_action( 'woocommerce_admin_field_' . $type, array( $this, 'custom_inline_element' ) );
+					if ( 'anon_id' === $id ) {
+						add_action( 'woocommerce_admin_field_' . $type, array( $this, 'custom_inline_element' ) );
+					}
 					// This intentionally falls through to the next section.
 
 				case self::TEXT:


### PR DESCRIPTION
'custom_inline_element'  I do remember that last time couldn't send this string via variable and couldn't know why  this way works