### PR TITLE
First draft of adding a dynamic "Actions" functionality to the settings page

### DIFF
--- a/dist/css/admin-settings.css
+++ b/dist/css/admin-settings.css
@@ -1,0 +1,44 @@
+.score_actions--ol {
+    list-style-type: none;
+    padding-left: 0;
+    margin-left: 0;
+    max-width: 800px;
+}
+
+.score_actions--ol > li {
+    background-color: #fff;
+    border: 1px solid #8c8f94;
+    border-width: 1px 1px 0;
+    margin: 0;
+    padding: 0.75em 2em;
+    line-height: 3em;
+}
+
+
+.score_actions--ol > li:first-child {
+    border-radius: 4px 4px 0 0;
+}
+
+.score_actions--ol > li:last-child {
+    border-width: 1px;
+    border-radius: 0 0 4px 4px;
+}
+
+.woocommerce table.form-table .score_actions--ol > li input[type=number] {
+    width: 55px;
+    vertical-align: middle;
+    padding: 2px 0 2px 10px;
+}
+
+.woocommerce table.form-table .score_actions--ol > li select {
+    width: auto;
+    vertical-align: middle;
+}
+
+.score_actions--ol > li .row-actions a {
+    text-decoration: none;
+}
+
+.sift--score_actions--add {
+    text-decoration: none;
+}

--- a/dist/js/admin-sift-score-actions.js
+++ b/dist/js/admin-sift-score-actions.js
@@ -1,0 +1,31 @@
+(function( $, wp ){
+
+    const $add     = $('.sift--score_actions--add');
+    const $list    = $('.score_actions--ol');
+    const tmpl_row = wp.template( 'score-action' );
+
+    $add.on( 'click', function(e) {
+        e.preventDefault();
+
+        $( tmpl_row( { row_slug: 'new-' + new Date().getTime() + '-' + Math.random() } ) ).appendTo( $list ).hide().slideDown( 200 );
+    });
+
+    $list.on( 'click', '.sift-delete', function(e) {
+        e.preventDefault();
+        const $li = $(e.target).closest('li');
+        $li.slideUp( 200, function() { $(this).remove(); } );
+    });
+
+    $list.on( 'click', '.sift-earlier', function(e) {
+        e.preventDefault();
+        const $li = $(e.target).closest('li');
+        $li.insertBefore( $li.prev() );
+    });
+
+    $list.on( 'click', '.sift-later', function(e) {
+        e.preventDefault();
+        const $li = $(e.target).closest('li');
+        $li.insertAfter( $li.next() );
+    });
+
+})( jQuery, wp );

--- a/includes/class-wc-siftscience-admin.php
+++ b/includes/class-wc-siftscience-admin.php
@@ -250,6 +250,7 @@ if ( ! class_exists( 'WC_SiftScience_Admin' ) ) :
 		 * @return Array [] the dictionary in which All fields are added.
 		 */
 		private function get_section_fields( $sub_section ) {
+			$this->html->enqueue_style( 'admin-settings' );
 
 			if ( 'main' === $sub_section ) {
 				$auto_update_settings = $this->options->get_order_auto_update_settings();
@@ -329,6 +330,18 @@ if ( ! class_exists( 'WC_SiftScience_Admin' ) ) :
 							'threshold_value' => $this->options->get_threshold_bad(),
 							'callback'        => 'gb_callback',
 							'status'          => $this->status->get_status_options(),
+						)
+					),
+
+					$this->wc_element->create(
+						WC_SiftScience_Element::CUSTOM,
+						'score_actions',
+						'Actions Based on Sift Score',
+						'The first action whose prerequisites are met will run, the rest will not. Scores run from 0-100, higher is more likely fraud, lower is more likely legitimate.',
+						array(
+							'actions'  => $this->options->get_score_actions(),
+							'status'   => $this->status->get_status_options(),
+							'callback' => 'score_actions_callback',
 						)
 					),
 
@@ -572,6 +585,22 @@ if ( ! class_exists( 'WC_SiftScience_Admin' ) ) :
 				$bad_to    = sanitize_key( $_REQUEST['bad_to'] );
 
 				$this->options->set_order_auto_update_settings( $good_from, $good_to, $bad_from, $bad_to );
+			}
+
+			if ( isset( $_REQUEST['score_actions'] ) ) {
+				$score_actions = array();
+
+				foreach ( $_REQUEST['score_actions'] as $_score_action ) {
+					$score_actions[] = array(
+						'comparison'   => preg_replace( '/[^\<\>=]/', '', $_score_action['comparison'] ),
+						'value'        => intval( $_score_action['value'] ),
+						'from_status'  => sanitize_key( $_score_action['from_status'] ),
+						'to_status'    => sanitize_key( $_score_action['to_status'] ),
+						'other_action' => sanitize_key( $_score_action['other_action'] ),
+					);
+				}
+
+				$this->options->set_score_actions( $score_actions );
 			}
 		}
 	}

--- a/includes/class-wc-siftscience-element.php
+++ b/includes/class-wc-siftscience-element.php
@@ -214,6 +214,84 @@ if ( ! class_exists( 'WC_SiftScience_Element' ) ) :
 			</tr>
 			<?php
 		}
+
+		/**
+		 * This function constructs the custom html for the listed actions ID field.
+		 */
+		public function score_actions_callback( array $data ) {
+			wp_enqueue_script( 'sift-score-actions', plugins_url( '../dist/js/admin-sift-score-actions.js', __FILE__ ), array( 'wp-util', 'jquery' ), false, true );
+
+			?>
+			<tr valign="top">
+				<th scope="row" class="titledesc">
+					<?php echo esc_html( $data['title'] ); ?>
+				</th>
+				<td class="forminp">
+					<ol class="score_actions--ol">
+						<?php foreach ( $data['actions'] as $row_slug => $action ) : ?>
+							<?php self::score_action_row_html( $row_slug, $action, $data ); ?>
+						<?php endforeach; ?>
+					</ol>
+					<a href="#" class="sift--score_actions--add">➕ Add Row</a>
+					<p><?php echo esc_html( $data['desc'] ); ?></p>
+
+					<script type="text/html" id="tmpl-score-action">
+						<?php echo self::score_action_row_html( '{{data.row_slug}}', null, $data ); ?>
+					</script>
+				</td>
+			</tr>
+			<?php
+		}
+
+		public static function score_action_row_html( $row_slug, $action = null, $data = array() ) {
+			$action = wp_parse_args(
+				$action,
+				array(
+					'comparison'   => null,
+					'value'        => null,
+					'from_status'  => null,
+					'to_status'    => null,
+					'other_action' => 'nothing',
+				)
+			);
+			?>
+			<li data-row-slug="<?php echo esc_attr( $row_slug ); ?>">
+				If the score is
+				<select name="score_actions[<?php echo esc_attr( $row_slug ); ?>][comparison]">
+					<option></option>
+					<option value=">" <?php selected( '>', $action['comparison'] ); ?>>></option>
+					<option value=">=" <?php selected( '>=', $action['comparison'] ); ?>>>=</option>
+					<option value="<=" <?php selected( '<=', $action['comparison'] ); ?>><=</option>
+					<option value="<" <?php selected( '<', $action['comparison'] ); ?>><</option>
+				</select>
+				<input type="number" min="0" max="100" name="score_actions[<?php echo esc_attr( $row_slug ); ?>][value]" value="<?php echo esc_attr( $action['value'] ); ?>" />
+				and the order status is
+				<select name="score_actions[<?php echo esc_attr( $row_slug ); ?>][from_status]">
+					<?php foreach ( $data['status'] as $key => $value ) : ?>
+						<option value="<?php echo esc_attr( $key ); ?>"<?php selected( $key, $action['from_status'] ); ?>><?php echo esc_html( $value ); ?></option>
+					<?php endforeach; ?>
+				</select>
+				,<br />&nbsp;&nbsp;&nbsp;&nbsp; then change the order status to
+				<select name="score_actions[<?php echo esc_attr( $row_slug ); ?>][to_status]">
+					<?php foreach ( $data['status'] as $key => $value ) : ?>
+						<option value="<?php echo esc_attr( $key ); ?>"<?php selected( $key, $action['to_status'] ); ?>><?php echo esc_html( $value ); ?></option>
+					<?php endforeach; ?>
+				</select>
+				and
+				<select name="score_actions[<?php echo esc_attr( $row_slug ); ?>][other_action]">
+					<option value="nothing" <?php selected( 'nothing', $action['other_action'] ); ?>>Nothing further</option>
+					<option value="email_admin" <?php selected( 'email_admin', $action['other_action'] ); ?>>E-mail an Admin</option>
+					<option value="cancel_all_users_orders" <?php selected( 'cancel_all_users_orders', $action['other_action'] ); ?>>Cancel any of the user&rsquo;s other orders</option>
+				</select>
+				<span class="row-actions">
+					<a href="#" class="sift-earlier" title="Move this rule earlier">🔼</a>
+					<a href="#" class="sift-later" title="Move this rule later">🔽</a>
+					<a href="#" class="sift-delete" title="Delete this Rule">❌</a>
+				</span>
+			</li>
+			<?php
+		}
+
 		/**
 		 *
 		 * Adds batch_upload element, the div must have the ID of batch-upload.

--- a/includes/class-wc-siftscience-options.php
+++ b/includes/class-wc-siftscience-options.php
@@ -58,6 +58,7 @@ if ( ! class_exists( 'WC_SiftScience_Options' ) ) :
 
 		public const THRESHOLD_GOOD    = self::SCHEMA . 'threshold_good';
 		public const THRESHOLD_BAD     = self::SCHEMA . 'threshold_bad';
+		public const SCORE_ACTIONS     = self::SCHEMA . 'score_actions';
 		public const AUTO_SEND_ENABLED = self::SCHEMA . 'auto_send_enabled';
 		public const MIN_ORDER_VALUE   = self::SCHEMA . 'min_order_value';
 		public const LOG_LEVEL_KEY     = self::SCHEMA . 'log_level';
@@ -184,6 +185,28 @@ if ( ! class_exists( 'WC_SiftScience_Options' ) ) :
 		 */
 		public function set_threshold_bad( int $value ) {
 			update_option( self::THRESHOLD_BAD, $value );
+		}
+
+		/**
+		 * Gets the available actions to take, based on Sift Score.
+		 */
+		public function get_score_actions() {
+			return get_option( self::SCORE_ACTIONS, array() );
+		}
+
+		/**
+		 * Sets the available actions to take, based on Sift Score.
+		 *
+		 * This should be an array of associative arrays.  Each option should have the following keys:
+		 *
+		 * `comparison`    (string) Either `>` `>=` `<=` or `<`
+		 * `value`         (integer) An integer between 0 and 100.
+		 * `from_status`   (string) One of `WC_SiftScience_Order_Status::get_status_options()`
+		 * `to_status`     (string) One of `WC_SiftScience_Order_Status::get_status_options()`
+		 * `other_actions` (string) Available extra actions we'd like to take.
+		 */
+		public function set_score_actions( array $actions ) {
+			update_option( self::SCORE_ACTIONS, $actions );
 		}
 
 		/**


### PR DESCRIPTION
Long-term, the goal would be for this to be a list of failover conditions, for more dynamic responses to fraud scores, rather than simply "above x is bad, below y is good"

To do yet:

* Add migration functionality to duplicate any data saved in the prior method in the new, so upgrades wouldn't lose configs.
* Update processing script to iterate through the new steps, if they are configured.
* Add processing for the "extra" actions that may be done in the end.

However, for the moment the settings are usable and save properly.

<img width="1379" alt="Screenshot 2023-10-06 at 2 43 16 PM" src="https://github.com/Fermiac/woocommerce-siftscience/assets/941023/deaba1b5-4055-4f1a-95bc-2314bdc987b9">


